### PR TITLE
fix return for old go version

### DIFF
--- a/uniuri.go
+++ b/uniuri.go
@@ -51,6 +51,8 @@ func NewLenChars(length int, chars []byte) string {
 	clen := byte(len(chars))
 	maxrb := byte(256 - (256 % len(chars)))
 	i := 0
+	var ret string
+	OuterLoop:
 	for {
 		if _, err := io.ReadFull(rand.Reader, r); err != nil {
 			panic("error reading from random source: " + err.Error())
@@ -63,8 +65,10 @@ func NewLenChars(length int, chars []byte) string {
 			b[i] = chars[c%clen]
 			i++
 			if i == length {
-				return string(b)
+				ret = string(b)
+				break OuterLoop
 			}
 		}
 	}
+	return ret
 }


### PR DESCRIPTION
I'm not a go expert, but I think that can fix this error: 
https://launchpadlibrarian.net/159564297/buildlog_ubuntu-raring-amd64.golang-uniri_0.1-0~15~ubuntu13.04.1_FAILEDTOBUILD.txt.gz

```
"src/github.com/dchest/uniuri/uniuri.go:48: function ends without a return statement"
```

according to this https://groups.google.com/forum/#!topic/golang-nuts/u66fQbfbzEo

Thank you :)

PS: JFYI, I created this: https://code.launchpad.net/~golang-uniuri/+archive/daily
a deb repository to use your package
