### PR TITLE
fixed an endless loop when length of chars is a divisor of 256

### DIFF
--- a/uniuri.go
+++ b/uniuri.go
@@ -56,7 +56,7 @@ func NewLenChars(length int, chars []byte) string {
 			panic("error reading from random source: " + err.Error())
 		}
 		for _, c := range r {
-			if c >= maxrb {
+			if c > maxrb {
 				// Skip this number to avoid modulo bias.
 				continue
 			}

--- a/uniuri_test.go
+++ b/uniuri_test.go
@@ -2,13 +2,7 @@ package uniuri
 
 import "testing"
 
-func TestNew(t *testing.T) {
-	u := New()
-	// Check length
-	if len(u) != StdLen {
-		t.Fatalf("wrong length: expected %d, got %d", StdLen, len(u))
-	}
-	// Check that only allowed characters are present
+func validateChars(t *testing.T, u string, chars []byte) {
 	for _, c := range u {
 		var present bool
 		for _, a := range StdChars {
@@ -20,6 +14,17 @@ func TestNew(t *testing.T) {
 			t.Fatalf("chars not allowed in %q", u)
 		}
 	}
+}
+
+func TestNew(t *testing.T) {
+	u := New()
+	// Check length
+	if len(u) != StdLen {
+		t.Fatalf("wrong length: expected %d, got %d", StdLen, len(u))
+	}
+	// Check that only allowed characters are present
+	validateChars(t, u, StdChars)
+
 	// Generate 1000 uniuris and check that they are unique
 	uris := make([]string, 1000)
 	for i, _ := range uris {
@@ -32,4 +37,17 @@ func TestNew(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestNewLenChars(t *testing.T) {
+	length := 10
+	chars := []byte("01234567")
+	u := NewLenChars(length, chars)
+
+	// Check length
+	if len(u) != length {
+		t.Fatalf("wrong length: expected %d, got %d", StdLen, len(u))
+	}
+	// Check that only allowed characters are present
+	validateChars(t, u, chars)
 }


### PR DESCRIPTION
Hi,

when using your package, I came across an edge case - `NewLenChars` drops into an infinite loop when the length of its `chars` parameter is a divisor of 256 - `maxrb` become zero in this case, an `c >= maxrb` is always true on line 59. I believe the correct condition here should be a strict greater-than (and, for example, [that page](http://zuttobenkyou.wordpress.com/2012/10/18/generating-random-numbers-without-modulo-bias/) supports this version, too) - and it makes sense, as we don't have a modulo bias in this case, as all possible values are equally represented in the remainder.

I also added a test to verify the correct behaviour of that function now, hope that helps.

Thank you.
