### PR TITLE
fixed the same value always generated for 256-divisor chars

### DIFF
--- a/uniuri.go
+++ b/uniuri.go
@@ -56,7 +56,7 @@ func NewLenChars(length int, chars []byte) string {
 			panic("error reading from random source: " + err.Error())
 		}
 		for _, c := range r {
-			if c > maxrb {
+			if maxrb > 0 && c > maxrb {
 				// Skip this number to avoid modulo bias.
 				continue
 			}

--- a/uniuri_test.go
+++ b/uniuri_test.go
@@ -50,4 +50,9 @@ func TestNewLenChars(t *testing.T) {
 	}
 	// Check that only allowed characters are present
 	validateChars(t, u, chars)
+	// Check that two generated strings are different
+	u2 := NewLenChars(length, chars)
+	if u == u2 {
+		t.Fatalf("not unique: %q and %q", u, u2)
+	}
 }


### PR DESCRIPTION
Actually, it looks like I haven't fixed it all in my previous pull request. I fixed the infinite loop, but it was just running out of data limit, and generating the same 0-byte return string every time. So I think the right way is just to explicitly test for `maxrb` being greater than zero, and do modulo bias check only when it is.

Test and code change again, hopefully the final one this time.
