### PR TITLE
Correct for bias towards first character in chars

### DIFF
--- a/uniuri.go
+++ b/uniuri.go
@@ -57,7 +57,7 @@ func NewLenChars(length int, chars []byte) string {
 	if clen > 256 {
 		panic("uniuri: maximum length of charset for NewLenChars is 256")
 	}
-	maxrb := 256 - (256 % clen)
+	maxrb := 255 - (256 % clen)
 	b := make([]byte, length)
 	r := make([]byte, length+(length/4)) // storage for random bytes.
 	i := 0


### PR DESCRIPTION
Currently the first character in chars has a 1/clen + 1/(maxrb+1) chance of being selected. In the case of StdChars the first character is ~25% more likely to be picked than any other character. This change gives a 1/clen chance to all characters, and is based on math/rand's Int31n(n).