### PR TITLE
Removed 1.3 & 1.4 Added 1.5 & 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
-
+arch:
+  - AMD64
+  - ppc64le
 go:
-  - 1.3
-  - 1.4
+  - 1.5
+  - 1.6
   - tip


### PR DESCRIPTION
Made few general changes related to go versions... please feel free to ping me.

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
