### PR TITLE
feature: functional options in constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,14 @@ Constants
 
 ```go
 const (
-	// StdLen is a standard length of uniuri string to achive ~95 bits of entropy.
-	StdLen = 16
-	// UUIDLen is a length of uniuri string to achive ~119 bits of entropy, closest
-	// to what can be losslessly converted to UUIDv4 (122 bits).
-	UUIDLen = 20
+// StdLen is a standard length of uniuri string to achive ~95 bits of entropy.
+StdLen = 16
+// UUIDLen is a length of uniuri string to achive ~119 bits of entropy, closest
+// to what can be losslessly converted to UUIDv4 (122 bits).
+UUIDLen = 20
 )
 
 ```
-
-
 
 Variables
 ---------
@@ -47,8 +45,8 @@ Variables
 var StdChars = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 ```
 
-
-StdChars is a set of standard characters allowed in uniuri string.
+StdChars is a set of standard characters allowed in uniuri string. It will be used by default by `New` and `NewBytes`
+functions unless option `Chars` given.
 
 
 Functions
@@ -57,30 +55,37 @@ Functions
 ### func New
 
 ```go
-func New() string
+func New(opts ...Opt) string
 ```
 
-New returns a new random string of the standard length, consisting of
-standard characters.
+New returns a new random string. It accepts zero or more functional options to change output.
 
 ### func NewLen
 
 ```go
-func NewLen(length int) string
+func NewBytes(opts ...Opt) string
 ```
 
-NewLen returns a new random string of the provided length, consisting of
-standard characters.
+New returns a new slice of random bytes. It accepts zero or more functional options to change output.
 
-### func NewLenChars
+Options
+---------
+
+### func Length
 
 ```go
-func NewLenChars(length int, chars []byte) string
+func Length(length int) Opt
 ```
 
-NewLenChars returns a new random string of the provided length, consisting
-of the provided byte slice of allowed characters (maximum 256).
+Sets length of random string or slice of bytes to be generated.
 
+### func Chars
+
+```go
+func Chars(chars []byte) Opt
+```
+
+Sets allowed characters to be used upon random string or slice of bytes generation.
 
 
 Public domain dedication

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Constants
 
 ```go
 const (
-// StdLen is a standard length of uniuri string to achive ~95 bits of entropy.
-StdLen = 16
-// UUIDLen is a length of uniuri string to achive ~119 bits of entropy, closest
-// to what can be losslessly converted to UUIDv4 (122 bits).
-UUIDLen = 20
+        // StdLen is a standard length of uniuri string to achive ~95 bits of entropy.
+        StdLen = 16
+        // UUIDLen is a length of uniuri string to achive ~119 bits of entropy, closest
+        // to what can be losslessly converted to UUIDv4 (122 bits).
+        UUIDLen = 20
 )
 
 ```

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,59 @@
+package uniuri
+
+import (
+	"testing"
+)
+
+var (
+	sixtyFourChars = append(testCharSet, []byte{'+', '/'}...)
+	sixtyFiveChars = append(sixtyFourChars, []byte{'.'}...)
+	threeChars     = []byte{'a', 'b', 'c'}
+)
+
+func BenchmarkLen16Chars65(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(StdLen, sixtyFiveChars)
+	}
+}
+
+func BenchmarkLen16Chars64(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(StdLen, sixtyFourChars)
+	}
+}
+
+func BenchmarkLen16Chars62(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(StdLen, testCharSet)
+	}
+}
+
+func BenchmarkLen16Chars3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(StdLen, threeChars)
+	}
+}
+
+func BenchmarkLen1024Chars65(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(1024, sixtyFiveChars)
+	}
+}
+
+func BenchmarkLen1024Chars64(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(1024, sixtyFourChars)
+	}
+}
+
+func BenchmarkLen1024Chars62(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(1024, testCharSet)
+	}
+}
+
+func BenchmarkLen1024Chars3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = generate(1024, threeChars)
+	}
+}

--- a/uniuri.go
+++ b/uniuri.go
@@ -39,8 +39,7 @@ const (
 // Deprecated: use functional options instead of slice modification
 var StdChars = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 
-// New returns a new random string of the standard length, consisting of
-// standard characters if no custom options given.
+// New returns a new random string or byte slice consisting of allowed characters.
 func New(opts ...Opt) string {
 	return string(NewBytes(opts...))
 }


### PR DESCRIPTION
This PR adds functional options to two main constructors (`New` and `NewBytes`) as well as setting deprecation notices to specific functions `NewLen`, `NewLenChars` and `NewLenCharsBytes`. Tests and benchmarks have been simplified and separated from actual code.

This changes are backward compatible, it is up to user to drop usage of deprecated functions and variables.